### PR TITLE
解决window glide问题

### DIFF
--- a/path/winbug.go
+++ b/path/winbug.go
@@ -72,7 +72,7 @@ func CustomRename(o, n string) error {
 	// Handking windows cases first
 	if runtime.GOOS == "windows" {
 		msg.Debug("Detected Windows. Moving files using windows command")
-		cmd := exec.Command("cmd.exe", "/c", "move", o, n)
+		cmd := exec.Command("robocopy.exe", o, n, "/e")
 		output, err := cmd.CombinedOutput()
 		if err != nil {
 			return fmt.Errorf("Error moving files: %s. output: %s", err, output)


### PR DESCRIPTION
[ERROR] Unable to export dependencies to vendor directory: Error moving files: exit status 1. output: Access is denied.
        0 dir(s) moved.